### PR TITLE
Add coveralls badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
-.. image:: https://coveralls.io/repos/github/opusonesolutions/carsons/badge.svg?branch=master
-:target: https://coveralls.io/github/opusonesolutions/carsons?branch=master
+carsons
+=======
 
+.. image:: https://coveralls.io/repos/github/opusonesolutions/carsons/badge.svg?branch=master
+  :target: https://coveralls.io/github/opusonesolutions/carsons?branch=master
 
 This is an implementation of Carson's Equations
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,7 @@
+.. image:: https://coveralls.io/repos/github/opusonesolutions/carsons/badge.svg?branch=master
+:target: https://coveralls.io/github/opusonesolutions/carsons?branch=master
+
+
 This is an implementation of Carson's Equations
 
 


### PR DESCRIPTION
I hooked this up at [coveralls.io](https://coveralls.io/github/opusonesolutions/carsons). It is reading 0% coverage rn but that should change once we merge https://github.com/opusonesolutions/carsons/pull/7.