### PR TITLE
Ensure the readme is read using UTF-8 encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = open(os.path.join(thisdir, 'carsons', 'VERSION')).read().strip()
 
 
 def readme():
-    with open("README.md", 'r') as f:
+    with open("README.md", 'r', encoding='UTF-8') as f:
         return f.read()
 
 


### PR DESCRIPTION
If the encoding is not specified, `locale.getpreferredencoding()` is used which is not guaranteed to be UTF-8.

Resolves #27 