### PR TITLE
Allow initialization of `CarsonsEquations` from a dictionary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Installation
 Usage
 -----
 
-Carsons model requires a line model object that maps each phase to
-properties of the conductor for that phase.
+Carsons model requires either a line model object or dictionary that maps
+each phase to properties of the conductor for that phase.
 
 ```python
 from carsons import CarsonsEquations, calculate_impedance

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -80,7 +80,7 @@ class CarsonsEquations():
             gmr = model.geometric_mean_radius
             r = model.resistance
             ƒ = getattr(model, 'frequency', 60)
-        
+
         self.phases: Iterable[str] = phases
         self.phase_positions: Dict[str, Tuple[float, float]] = \
             phase_positions
@@ -91,10 +91,6 @@ class CarsonsEquations():
         self.ω = 2.0 * π * self.ƒ  # angular frequency radians / second
 
     def build_z_primitive(self):
-        abc_conductors = [
-            ph if ph in self.phases
-            else None for ph in ("A", "B", "C")
-        ]
         neutral_conductors = sorted([
             ph for ph in self.phases
             if ph.startswith("N")
@@ -229,7 +225,8 @@ class ConcentricNeutralCarsonsEquations(CarsonsEquations):
         self.neutral_strand_count: Dict[str, float] = defaultdict(
             lambda: None, neutral_strand_count
         )
-        self.neutral_strand_resistance: Dict[str, float] = neutral_strand_resistance
+        self.neutral_strand_resistance: Dict[str, float] = \
+            neutral_strand_resistance
         self.radius: Dict[str, float] = defaultdict(lambda: None, {
             phase: (diameter_over_neutral - neutral_strand_diameter[phase]) / 2
             for phase, diameter_over_neutral

--- a/tests/test_carsons.py
+++ b/tests/test_carsons.py
@@ -8,6 +8,7 @@ from carsons.carsons import (
 from tests.test_overhead_line import (
     ACBN_geometry_line,
     CN_geometry_line,
+    CN_geometry_line_dict,
 )
 
 
@@ -139,7 +140,8 @@ def expected_z_abc_three_neutrals():
 @pytest.mark.parametrize(
     "line,z_primitive_expected",
     [(ACBN_geometry_line(), ACBN_line_z_primitive()),
-     (CN_geometry_line(), CN_line_z_primitive())])
+     (CN_geometry_line(), CN_line_z_primitive()),
+     (CN_geometry_line_dict, CN_line_z_primitive())])
 def test_unbalanced_carsons_equations(line, z_primitive_expected):
     model = CarsonsEquations(line)
     z_primitive_computed = model.build_z_primitive()

--- a/tests/test_overhead_line.py
+++ b/tests/test_overhead_line.py
@@ -201,7 +201,6 @@ def CN_line_phase_impedance_50Hz():
     [(ACBN_geometry_line, 60, ACBN_line_phase_impedance_60Hz()),
      (CBN_geometry_line, 60, CBN_line_phase_impedance_60Hz()),
      (CN_geometry_line, 60, CN_line_phase_impedance_60Hz()),
-     
      (ACBN_geometry_line, 50, ACBN_line_phase_impedance_50Hz()),
      (CBN_geometry_line, 50, CBN_line_phase_impedance_50Hz()),
      (CN_geometry_line, 50, CN_line_phase_impedance_50Hz())])

--- a/tests/test_overhead_line.py
+++ b/tests/test_overhead_line.py
@@ -160,6 +160,26 @@ class CN_geometry_line():
         ]
 
 
+CN_geometry_line_dict = {
+    'resistance': {
+        'C': 0.000695936,
+        'N': 0.000695936,
+    },
+    'geometric_mean_radius': {
+        'C': 0.00135941,
+        'N': 0.00135941,
+    },
+    'wire_positions': {
+        'C': (0, 8.8392),
+        'N': (0.1524, 7.3152),
+    },
+    'phases': [
+        'C',
+        'N'
+    ]
+}
+
+
 def CN_line_phase_impedance_60Hz():
     """ IEEE 13 Configuration 605 Impedance Solution At 60Hz """
     return OHM_PER_MILE_TO_OHM_PER_METER * array([
@@ -181,6 +201,7 @@ def CN_line_phase_impedance_50Hz():
     [(ACBN_geometry_line, 60, ACBN_line_phase_impedance_60Hz()),
      (CBN_geometry_line, 60, CBN_line_phase_impedance_60Hz()),
      (CN_geometry_line, 60, CN_line_phase_impedance_60Hz()),
+     
      (ACBN_geometry_line, 50, ACBN_line_phase_impedance_50Hz()),
      (CBN_geometry_line, 50, CBN_line_phase_impedance_50Hz()),
      (CN_geometry_line, 50, CN_line_phase_impedance_50Hz())])
@@ -189,3 +210,18 @@ def test_converts_geometry_to_phase_impedance(
     actual_impedance = convert_geometric_model(line(ƒ=frequency))
     assert_array_almost_equal(expected_impedance,
                               actual_impedance)
+
+
+@pytest.mark.parametrize(
+    "line,frequency,expected_impedance",
+    [
+        (CN_geometry_line_dict, 60, CN_line_phase_impedance_60Hz()),
+        (CN_geometry_line_dict, 50, CN_line_phase_impedance_50Hz()),
+    ]
+)
+def test_convers_geometry_dict_to_phase_impedance(
+    line, frequency, expected_impedance
+):
+    line['ƒ'] = frequency
+    actual_impedance = convert_geometric_model(line)
+    assert_array_almost_equal(expected_impedance, actual_impedance)


### PR DESCRIPTION
This change eliminates the need to always construct a model object to use Carson's equations. In the future, we can simplify the test code to use these dictionaries instead of classes.

Resolves #30 