### PR TITLE
Extract Overhead Line Tests Into New Test File

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ z_primitive = CarsonsEquations(Line()).build_z_primitive()
 ```
 
 For examples of how to use the model, see the [overhead wire
-tests](https://github.com/opusonesolutions/carsons/blob/master/tests/test_carsons.py).
+tests](https://github.com/opusonesolutions/carsons/blob/master/tests/test_overhead_line.py).
 
 `carsons` is tested against several cable configurations from the [IEEE
 test feeders](http://sites.ieee.org/pes-testfeeders/resources/), as well as

--- a/tests/test_carsons.py
+++ b/tests/test_carsons.py
@@ -3,133 +3,12 @@ from numpy.testing import assert_array_almost_equal
 from numpy import array
 from carsons.carsons import (
     CarsonsEquations,
-    convert_geometric_model,
     perform_kron_reduction,
 )
-
-# `carsons` implements the model entirely in SI metric units, however this
-# conversion allows us to enter in impedance as ohm-per-mile in the test
-# harness, which means we can lift matrices directly out of the ieee test
-# network.
-OHM_PER_MILE_TO_OHM_PER_METER = 1 / 1_609.344
-OHM_PER_KILOMETER_TO_OHM_PER_METER = 1 / 1_000
-
-
-class ACBN_geometry_line():
-    """ IEEE 13 Configuration 601 Line Geometry """
-
-    def __init__(self, ƒ=60):
-        self.frequency = ƒ
-
-    @property
-    def resistance(self):
-        return {
-            'A': 0.000115575,
-            'C': 0.000115575,
-            'B': 0.000115575,
-            'N': 0.000367852,
-        }
-
-    @property
-    def geometric_mean_radius(self):
-        return {
-            'A': 0.00947938,
-            'C': 0.00947938,
-            'B': 0.00947938,
-            'N': 0.00248107,
-        }
-
-    @property
-    def wire_positions(self):
-        return {
-            'A': (0.762, 8.5344),
-            'C': (2.1336, 8.5344),
-            'B': (0, 8.5344),
-            'N': (1.2192, 7.3152),
-        }
-
-    @property
-    def phases(self):
-        return [
-            'A',
-            'C',
-            'B',
-            'N',
-        ]
-
-
-class CBN_geometry_line():
-    """ IEEE 13 Configuration 603 Line Geometry """
-
-    def __init__(self, ƒ=60):
-        self.frequency = ƒ
-
-    @property
-    def resistance(self):
-        return {
-            'B': 0.000695936,
-            'C': 0.000695936,
-            'N': 0.000695936,
-        }
-
-    @property
-    def geometric_mean_radius(self):
-        return {
-            'B': 0.00135941,
-            'C': 0.00135941,
-            'N': 0.00135941,
-        }
-
-    @property
-    def wire_positions(self):
-        return {
-            'B': (2.1336, 8.5344),
-            'C': (0, 8.5344),
-            'N': (1.2192, 7.3152),
-        }
-
-    @property
-    def phases(self):
-        return [
-            'B',
-            'C',
-            'N',
-        ]
-
-
-class CN_geometry_line():
-    """ IEEE 13 Configuration 605 Line Geometry"""
-
-    def __init__(self, ƒ=60):
-        self.frequency = ƒ
-
-    @property
-    def resistance(self):
-        return {
-            'C': 0.000695936,
-            'N': 0.000695936,
-        }
-
-    @property
-    def geometric_mean_radius(self):
-        return {
-            'C': 0.00135941,
-            'N': 0.00135941,
-        }
-
-    @property
-    def wire_positions(self):
-        return {
-            'C': (0, 8.8392),
-            'N': (0.1524, 7.3152),
-        }
-
-    @property
-    def phases(self):
-        return [
-            'C',
-            'N',
-        ]
+from tests.test_overhead_line import (
+    ACBN_geometry_line,
+    CN_geometry_line,
+)
 
 
 class ABCN_balanced_line():
@@ -171,42 +50,6 @@ class ABCN_balanced_line():
         ]
 
 
-def ACBN_line_phase_impedance():
-    """ IEEE 13 Configuration 601 Impedance Solution At 60Hz """
-    return OHM_PER_MILE_TO_OHM_PER_METER * array([
-            [0.3465 + 1.0179j, 0.1560 + 0.5017j, 0.1580 + 0.4236j],
-            [0.1560 + 0.5017j, 0.3375 + 1.0478j, 0.1535 + 0.3849j],
-            [0.1580 + 0.4236j, 0.1535 + 0.3849j, 0.3414 + 1.0348j]])
-
-
-def ACBN_line_phase_impedance_50Hz():
-    """ IEEE 13 Configuration 601 Impedance Solution At 50Hz """
-    return OHM_PER_KILOMETER_TO_OHM_PER_METER * array([
-            [0.2101 + 0.5372j,  0.09171 + 0.2691j, 0.09295 + 0.2289j],
-            [0.09171 + 0.2691j, 0.20460 + 0.552j,  0.09021 + 0.2085j],
-            [0.09295 + 0.2289j, 0.09021 + 0.2085j, 0.207 + 0.5456j]])
-
-
-def ACBN_line_z_primitive():
-    return array([
-        [1.74792626e-04+0.00085989j,
-         5.92176264e-05+0.00052913j,
-         5.92176264e-05+0.00048481j,
-         5.92176264e-05+0.00048873j],
-        [5.92176264e-05+0.00052913j,
-         1.74792626e-04+0.00085989j,
-         5.92176264e-05+0.0004515j,
-         5.92176264e-05+0.00046756j],
-        [5.92176264e-05+0.00048481j,
-         5.92176264e-05+0.0004515j,
-         1.74792626e-04+0.00085989j,
-         5.92176264e-05+0.00047687j],
-        [5.92176264e-05+0.00048873j,
-         5.92176264e-05+0.00046756j,
-         5.92176264e-05+0.00047687j,
-         4.27069626e-04+0.00096095j]])
-
-
 def ABCN_balanced_z_primitive():
     return array([
         [1.74792626e-04+0.00085989j,
@@ -228,36 +71,24 @@ def ABCN_balanced_z_primitive():
     ])
 
 
-def CBN_line_phase_impedance():
-    """ IEEE 13 Configuration 603 Impedance Solution At 60Hz """
-    return OHM_PER_MILE_TO_OHM_PER_METER * array([
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
-            [0.0000 + 0.0000j, 1.3294 + 1.3471j, 0.2066 + 0.4591j],
-            [0.0000 + 0.0000j, 0.2066 + 0.4591j, 1.3238 + 1.3569j]])
-
-
-def CBN_line_phase_impedance_50Hz():
-    """ IEEE 13 Configuration 603 Impedance Solution At 50Hz """
-    return OHM_PER_KILOMETER_TO_OHM_PER_METER * array([
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
-            [0.0000 + 0.0000j, 0.8128 + 0.7144j, 0.1153 + 0.2543j],
-            [0.0000 + 0.0000j, 0.1153 + 0.2543j, 0.8097 + 0.7189j]])
-
-
-def CN_line_phase_impedance():
-    """ IEEE 13 Configuration 605 Impedance Solution At 60Hz """
-    return OHM_PER_MILE_TO_OHM_PER_METER * array([
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 1.3292 + 1.3475j]])
-
-
-def CN_line_phase_impedance_50Hz():
-    """ IEEE 13 Configuration 605 Impedance Solution At 50Hz """
-    return OHM_PER_KILOMETER_TO_OHM_PER_METER * array([
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
-            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.8127 + 0.7146j]])
+def ACBN_line_z_primitive():
+    return array([
+        [1.74792626e-04+0.00085989j,
+         5.92176264e-05+0.00052913j,
+         5.92176264e-05+0.00048481j,
+         5.92176264e-05+0.00048873j],
+        [5.92176264e-05+0.00052913j,
+         1.74792626e-04+0.00085989j,
+         5.92176264e-05+0.0004515j,
+         5.92176264e-05+0.00046756j],
+        [5.92176264e-05+0.00048481j,
+         5.92176264e-05+0.0004515j,
+         1.74792626e-04+0.00085989j,
+         5.92176264e-05+0.00047687j],
+        [5.92176264e-05+0.00048873j,
+         5.92176264e-05+0.00046756j,
+         5.92176264e-05+0.00047687j,
+         4.27069626e-04+0.00096095j]])
 
 
 def CN_line_z_primitive():
@@ -303,21 +134,6 @@ def expected_z_abc_three_neutrals():
                 [-13 + 0j, -14 + 0j, -14 + 0j],
                 [-14 + 0j, -13 + 0j, -14 + 0j],
                 [-14 + 0j, -14 + 0j, -13 + 0j]])
-
-
-@pytest.mark.parametrize(
-    "line,frequency,expected_impedance",
-    [(ACBN_geometry_line, 60, ACBN_line_phase_impedance()),
-     (CBN_geometry_line, 60, CBN_line_phase_impedance()),
-     (CN_geometry_line, 60, CN_line_phase_impedance()),
-     (ACBN_geometry_line, 50, ACBN_line_phase_impedance_50Hz()),
-     (CBN_geometry_line, 50, CBN_line_phase_impedance_50Hz()),
-     (CN_geometry_line, 50, CN_line_phase_impedance_50Hz())])
-def test_converts_geometry_to_phase_impedance(
-        line, frequency, expected_impedance):
-    actual_impedance = convert_geometric_model(line(ƒ=frequency))
-    assert_array_almost_equal(expected_impedance,
-                              actual_impedance)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_concentric_neutral_cable.py
+++ b/tests/test_concentric_neutral_cable.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_almost_equal
 
 from carsons import ConcentricNeutralCarsonsEquations, calculate_impedance
 from tests.helpers import ConcentricLineModel
-from tests.test_carsons import OHM_PER_MILE_TO_OHM_PER_METER
+from tests.test_overhead_line import OHM_PER_MILE_TO_OHM_PER_METER
 
 ureg = pint.UnitRegistry()
 

--- a/tests/test_overhead_line.py
+++ b/tests/test_overhead_line.py
@@ -1,0 +1,191 @@
+import pytest
+from numpy.testing import assert_array_almost_equal
+from numpy import array
+from carsons.carsons import convert_geometric_model
+
+# `carsons` implements the model entirely in SI metric units, however this
+# conversion allows us to enter in impedance as ohm-per-mile in the test
+# harness, which means we can lift matrices directly out of the ieee test
+# networks.
+OHM_PER_MILE_TO_OHM_PER_METER = 1 / 1_609.344
+OHM_PER_KILOMETER_TO_OHM_PER_METER = 1 / 1_000
+
+
+class ACBN_geometry_line():
+    """ IEEE 13 Configuration 601 Line Geometry """
+
+    def __init__(self, ƒ=60):
+        self.frequency = ƒ
+
+    @property
+    def resistance(self):
+        return {
+            'A': 0.000115575,
+            'C': 0.000115575,
+            'B': 0.000115575,
+            'N': 0.000367852,
+        }
+
+    @property
+    def geometric_mean_radius(self):
+        return {
+            'A': 0.00947938,
+            'C': 0.00947938,
+            'B': 0.00947938,
+            'N': 0.00248107,
+        }
+
+    @property
+    def wire_positions(self):
+        return {
+            'A': (0.762, 8.5344),
+            'C': (2.1336, 8.5344),
+            'B': (0, 8.5344),
+            'N': (1.2192, 7.3152),
+        }
+
+    @property
+    def phases(self):
+        return [
+            'A',
+            'C',
+            'B',
+            'N',
+        ]
+
+
+def ACBN_line_phase_impedance_60Hz():
+    """ IEEE 13 Configuration 601 Impedance Solution At 60Hz """
+    return OHM_PER_MILE_TO_OHM_PER_METER * array([
+            [0.3465 + 1.0179j, 0.1560 + 0.5017j, 0.1580 + 0.4236j],
+            [0.1560 + 0.5017j, 0.3375 + 1.0478j, 0.1535 + 0.3849j],
+            [0.1580 + 0.4236j, 0.1535 + 0.3849j, 0.3414 + 1.0348j]])
+
+
+def ACBN_line_phase_impedance_50Hz():
+    """ IEEE 13 Configuration 601 Impedance Solution At 50Hz """
+    return OHM_PER_KILOMETER_TO_OHM_PER_METER * array([
+            [0.2101 + 0.5372j,  0.09171 + 0.2691j, 0.09295 + 0.2289j],
+            [0.09171 + 0.2691j, 0.20460 + 0.552j,  0.09021 + 0.2085j],
+            [0.09295 + 0.2289j, 0.09021 + 0.2085j, 0.207 + 0.5456j]])
+
+
+class CBN_geometry_line():
+    """ IEEE 13 Configuration 603 Line Geometry """
+
+    def __init__(self, ƒ=60):
+        self.frequency = ƒ
+
+    @property
+    def resistance(self):
+        return {
+            'B': 0.000695936,
+            'C': 0.000695936,
+            'N': 0.000695936,
+        }
+
+    @property
+    def geometric_mean_radius(self):
+        return {
+            'B': 0.00135941,
+            'C': 0.00135941,
+            'N': 0.00135941,
+        }
+
+    @property
+    def wire_positions(self):
+        return {
+            'B': (2.1336, 8.5344),
+            'C': (0, 8.5344),
+            'N': (1.2192, 7.3152),
+        }
+
+    @property
+    def phases(self):
+        return [
+            'B',
+            'C',
+            'N',
+        ]
+
+
+def CBN_line_phase_impedance_60Hz():
+    """ IEEE 13 Configuration 603 Impedance Solution At 60Hz """
+    return OHM_PER_MILE_TO_OHM_PER_METER * array([
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
+            [0.0000 + 0.0000j, 1.3294 + 1.3471j, 0.2066 + 0.4591j],
+            [0.0000 + 0.0000j, 0.2066 + 0.4591j, 1.3238 + 1.3569j]])
+
+
+def CBN_line_phase_impedance_50Hz():
+    """ IEEE 13 Configuration 603 Impedance Solution At 50Hz """
+    return OHM_PER_KILOMETER_TO_OHM_PER_METER * array([
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
+            [0.0000 + 0.0000j, 0.8128 + 0.7144j, 0.1153 + 0.2543j],
+            [0.0000 + 0.0000j, 0.1153 + 0.2543j, 0.8097 + 0.7189j]])
+
+
+class CN_geometry_line():
+    """ IEEE 13 Configuration 605 Line Geometry"""
+
+    def __init__(self, ƒ=60):
+        self.frequency = ƒ
+
+    @property
+    def resistance(self):
+        return {
+            'C': 0.000695936,
+            'N': 0.000695936,
+        }
+
+    @property
+    def geometric_mean_radius(self):
+        return {
+            'C': 0.00135941,
+            'N': 0.00135941,
+        }
+
+    @property
+    def wire_positions(self):
+        return {
+            'C': (0, 8.8392),
+            'N': (0.1524, 7.3152),
+        }
+
+    @property
+    def phases(self):
+        return [
+            'C',
+            'N',
+        ]
+
+
+def CN_line_phase_impedance_60Hz():
+    """ IEEE 13 Configuration 605 Impedance Solution At 60Hz """
+    return OHM_PER_MILE_TO_OHM_PER_METER * array([
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 1.3292 + 1.3475j]])
+
+
+def CN_line_phase_impedance_50Hz():
+    """ IEEE 13 Configuration 605 Impedance Solution At 50Hz """
+    return OHM_PER_KILOMETER_TO_OHM_PER_METER * array([
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.0000 + 0.0000j],
+            [0.0000 + 0.0000j, 0.0000 + 0.0000j, 0.8127 + 0.7146j]])
+
+
+@pytest.mark.parametrize(
+    "line,frequency,expected_impedance",
+    [(ACBN_geometry_line, 60, ACBN_line_phase_impedance_60Hz()),
+     (CBN_geometry_line, 60, CBN_line_phase_impedance_60Hz()),
+     (CN_geometry_line, 60, CN_line_phase_impedance_60Hz()),
+     (ACBN_geometry_line, 50, ACBN_line_phase_impedance_50Hz()),
+     (CBN_geometry_line, 50, CBN_line_phase_impedance_50Hz()),
+     (CN_geometry_line, 50, CN_line_phase_impedance_50Hz())])
+def test_converts_geometry_to_phase_impedance(
+        line, frequency, expected_impedance):
+    actual_impedance = convert_geometric_model(line(ƒ=frequency))
+    assert_array_almost_equal(expected_impedance,
+                              actual_impedance)


### PR DESCRIPTION
- Previously api tests for overhead lines were combined with internal functional tests into one test file called `test_carsons.py`. 
- To make tests easier to read, overhead lines api tests have been extracted into its own file: `test_overhead_line.py`. This is analogous to the `test_concentric_neutral_cable.py` test.
