### PR TITLE
Support multi-conductor cables

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,23 +187,23 @@ is a 2 x 2 matrix.
 ```python
 class Cable:
     resistance: {
-        'S1': per-length resistance of conductor A in ohm/meters
+        'S1': per-length resistance of conductor S1 in ohm/meters
         ...
     }
     geometric_mean_radius: {
-        'S1': geometric mean radius of conductor A in meters
+        'S1': geometric mean radius of conductor S1 in meters
         ...
     }
     wire_positions: {
-        'S1': (x, y) cross-sectional position of conductor A in meters
+        'S1': (x, y) cross-sectional position of conductor S1 in meters
         ...
     }
     radius: {
-        'S1': radius of conductor A
+        'S1': radius of conductor S1
         ...
     }
     insulation_thickness: {
-        'S1': insulation thickness of conductor A
+        'S1': insulation thickness of conductor S1
         ...
     }
     phases: {'S1', ... }

--- a/README.md
+++ b/README.md
@@ -151,9 +151,6 @@ tests](https://github.com/opusonesolutions/carsons/blob/master/tests/test_concen
 `carsons` also supports modelling of phased duplex, triplex, quadruplex cables and triplex secondary.
 It only requires a few more parameters to describe cable's geometry.
 
-A flag `is_secondary` is used to identify whether a cable is a triplex secondary. The impedance result
-is a 2 x 2 matrix with each row and column being its secondary conductors.
-
 ```python
 from carsons import (MultiConductorCarsonsEquations,
                      calculate_impedance)
@@ -180,9 +177,36 @@ class Cable:
         ...
     }
     phases: {'A', ... }
-    is_secondary: True
 
 cable_impedance = calculate_impedance(MultiConductorCarsonsEquations(Cable()))
+```
+
+To model a triplex secondary cable, the inputs should be keyed on secondary conductors `S1` and `S2`. The impedance result
+is a 2 x 2 matrix.
+
+```python
+class Cable:
+    resistance: {
+        'S1': per-length resistance of conductor A in ohm/meters
+        ...
+    }
+    geometric_mean_radius: {
+        'S1': geometric mean radius of conductor A in meters
+        ...
+    }
+    wire_positions: {
+        'S1': (x, y) cross-sectional position of conductor A in meters
+        ...
+    }
+    radius: {
+        'S1': radius of conductor A
+        ...
+    }
+    insulation_thickness: {
+        'S1': insulation thickness of conductor A
+        ...
+    }
+    phases: {'S1', ... }
 ```
 
 For examples of how to use the model, see the [multi-conductor cable

--- a/README.md
+++ b/README.md
@@ -146,6 +146,48 @@ cable_impedance = calculate_impedance(ConcentricNeutralCarsonsEquations(Cable())
 For examples of how to use the model, see the [concentric cable
 tests](https://github.com/opusonesolutions/carsons/blob/master/tests/test_concentric_neutral_cable.py).
 
+### Multi-Conductor Cable
+
+`carsons` also supports modelling of phased duplex, triplex, quadruplex cables and triplex secondary.
+It only requires a few more parameters to describe cable's geometry.
+
+A flag `is_secondary` is used to identify whether a cable is a triplex secondary. The impedance result
+is a 2 x 2 matrix with each row and column being its secondary conductors.
+
+```python
+from carsons import (MultiConductorCarsonsEquations,
+                     calculate_impedance)
+
+class Cable:
+    resistance: {
+        'A': per-length resistance of conductor A in ohm/meters
+        ...
+    }
+    geometric_mean_radius: {
+        'A': geometric mean radius of conductor A in meters
+        ...
+    }
+    wire_positions: {
+        'A': (x, y) cross-sectional position of conductor A in meters
+        ...
+    }
+    radius: {
+        'A': radius of conductor A
+        ...
+    }
+    insulation_thickness: {
+        'A': insulation thickness of conductor A
+        ...
+    }
+    phases: {'A', ... }
+    is_secondary: True
+
+cable_impedance = calculate_impedance(MultiConductorCarsonsEquations(Cable()))
+```
+
+For examples of how to use the model, see the [multi-conductor cable
+tests](https://github.com/opusonesolutions/carsons/blob/master/tests/test_multi_conductor.py).
+
 Problem Description
 -------------------
 

--- a/carsons/__init__.py
+++ b/carsons/__init__.py
@@ -1,5 +1,6 @@
 from carsons.carsons import (convert_geometric_model,               # noqa 401
-                             calculate_impedance,                             # noqa 401
-                             ConcentricNeutralCarsonsEquations)     # noqa 401
+                             calculate_impedance,                   # noqa 401
+                             ConcentricNeutralCarsonsEquations,     # noqa 401
+                             MultiConductorCarsonsEquations)        # noqa 401
 
 name = "carsons"

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -18,9 +18,7 @@ def convert_geometric_model(geometric_model) -> ndarray:
 
 def calculate_impedance(model) -> ndarray:
     z_primitive = model.build_z_primitive()
-
-    dim = 2 if getattr(model, 'secondary', False) else 3
-    z_abc = perform_kron_reduction(z_primitive, dimension=dim)
+    z_abc = perform_kron_reduction(z_primitive, dimension=model.dimension)
 
     return z_abc
 
@@ -194,6 +192,10 @@ class CarsonsEquations():
     def get_h(self, i):
         _, yᵢ = self.phase_positions[i]
         return yᵢ
+
+    @property
+    def dimension(self):
+        return 2 if getattr(self, 'secondary', False) else 3
 
 
 class ConcentricNeutralCarsonsEquations(CarsonsEquations):

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -210,7 +210,8 @@ class ModifiedCarsonsEquations(CarsonsEquations):
 
     def compute_R(self, i, j) -> float:
         rᵢ = self.r[i]
-        ΔR = self.μ * self.ω / π * super().compute_P(i, j, self.number_of_P_terms)
+        ΔR = self.μ * self.ω / π * super().compute_P(
+            i, j, self.number_of_P_terms)
 
         if i == j:
             return rᵢ + ΔR
@@ -304,9 +305,10 @@ class MultiConductorCarsonsEquations(ModifiedCarsonsEquations):
 
     def compute_d(self, i, j) -> float:
         # Assumptions:
-        # 1. All conductors in the cable are touching each other and therefore equidistant.
-        # 2. In case of quadruplex cables, the space between conductors which are
-        #    diagonally positioned is neglected.
+        # 1. All conductors in the cable are touching each other and
+        #    therefore equidistant.
+        # 2. In case of quadruplex cables, the space between conductors
+        #    which are diagonally positioned is neglected.
         return (self.radius[i] + self.radius[j]
                 + self.insulation_thickness[i] + self.insulation_thickness[j])
 

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -304,9 +304,6 @@ class MultiConductorCarsonsEquations(ModifiedCarsonsEquations):
         return (self.radius[i] + self.radius[j]
                 + self.insulation_thickness[i] + self.insulation_thickness[j])
 
-    def compute_D(self, i, j) -> float:
-        return self.phase_positions[i][1] + self.phase_positions[j][1]
-
     @property
     def conductors(self):
         neutral_conductors = sorted([

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -277,7 +277,8 @@ class MultiConductorCarsonsEquations(CarsonsEquations):
         super().__init__(model)
         self.radius: Dict[str, float] = model.radius
         self.secondary: bool = model.secondary
-        self.insulation_thickness: Dict[str, float] = model.insulation_thickness
+        self.insulation_thickness: Dict[str, float] = \
+            model.insulation_thickness
 
     def build_z_primitive(self) -> ndarray:
         neutral_conductors = sorted([

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -208,15 +208,8 @@ class ModifiedCarsonsEquations(CarsonsEquations):
     """
     number_of_P_terms = 1
 
-    def compute_R(self, i, j) -> float:
-        rᵢ = self.r[i]
-        ΔR = self.μ * self.ω / π * super().compute_P(
-            i, j, self.number_of_P_terms)
-
-        if i == j:
-            return rᵢ + ΔR
-        else:
-            return ΔR
+    def compute_P(self, i, j, number_of_terms=1) -> float:
+        return super().compute_P(i, j, self.number_of_P_terms)
 
     def compute_X(self, i, j) -> float:
         Q_first_term = super().compute_Q(i, j, 1)

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -189,7 +189,7 @@ class CarsonsEquations():
 
     @property
     def dimension(self):
-        return 2 if getattr(self, 'secondary', False) else 3
+        return 2 if getattr(self, 'is_secondary', False) else 3
 
     @property
     def conductors(self):
@@ -299,7 +299,6 @@ class MultiConductorCarsonsEquations(ModifiedCarsonsEquations):
     def __init__(self, model):
         super().__init__(model)
         self.radius: Dict[str, float] = model.radius
-        self.secondary: bool = model.secondary
         self.insulation_thickness: Dict[str, float] = \
             model.insulation_thickness
 
@@ -318,19 +317,19 @@ class MultiConductorCarsonsEquations(ModifiedCarsonsEquations):
     @property
     def conductors(self):
         neutral_conductors = sorted([
-            ph for ph in self.phases
-            if ph.startswith("N")
+            ph for ph in self.phases if ph.startswith("N")
         ])
-        if self.secondary:
-            secondary_conductors = ['S1', 'S2']
-            conductors = secondary_conductors + neutral_conductors
-            ph = (set(self.phases) - set(neutral_conductors)).pop()
-            for k, v in self.__dict__.items():
-                if isinstance(v, dict):
-                    prop = v.pop(ph)
-                    v.update({k: prop for k in secondary_conductors})
-            self.phases = conductors
+        if self.is_secondary:
+            conductors = ["S1", "S2"] + neutral_conductors
         else:
             conductors = ["A", "B", "C"] + neutral_conductors
 
         return conductors
+
+    @property
+    def is_secondary(self):
+        phase_conductors = [ph for ph in self.phases if not ph.startswith('N')]
+        if phase_conductors == ["S1", "S2"]:
+            return True
+        else:
+            return False

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -265,3 +265,16 @@ class ConcentricNeutralCarsonsEquations(CarsonsEquations):
         k = self.neutral_strand_count[phase]
         R = self.radius[phase]
         return (GMR_s * k * R**(k-1))**(1/k)
+
+
+class MultiConductorCarsonsEquations(CarsonsEquations):
+    def __init__(self, model):
+        super().__init__(model)
+        self.radius: Dict[str, float] = model.radius
+
+    def compute_d(self, i, j) -> float:
+        return self.radius[i] + self.radius[j]
+
+    def compute_D(self, i, j) -> float:
+        x, y = self.phase_positions[i]
+        return 2 * y

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -286,6 +286,10 @@ class MultiConductorCarsonsEquations(CarsonsEquations):
             model.insulation_thickness
 
     def compute_d(self, i, j) -> float:
+        # Assumptions:
+        # 1. All conductors in the cable are touching each other and therefore equidistant.
+        # 2. In case of quadruplex cables, the space between conductors which are
+        #    diagonally positioned is neglected.
         return (self.radius[i] + self.radius[j]
                 + self.insulation_thickness[i] + self.insulation_thickness[j])
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -106,7 +106,6 @@ class MultiLineModel:
             self._insulation_thickness[phase] = val['insulation_thickness']
 
         self._phases = sorted(list(conductors.keys()))
-        self._secondary = is_secondary
 
     @property
     def resistance(self):
@@ -131,7 +130,3 @@ class MultiLineModel:
     @property
     def insulation_thickness(self):
         return self._insulation_thickness
-
-    @property
-    def secondary(self):
-        return self._secondary

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -91,20 +91,22 @@ class ConcentricLineModel:
 
 
 class MultiLineModel:
-    def __init__(self, conductors):
+    def __init__(self, conductors, is_secondary=False):
         self._resistance = {}
         self._geometric_mean_radius = {}
         self._wire_positions = {}
-        self._phases = {}
         self._radius = {}
+        self._insulation_thickness = {}
 
         for phase, val in conductors.items():
             self._resistance[phase] = val['resistance']
             self._geometric_mean_radius[phase] = val['gmr']
             self._wire_positions[phase] = val['wire_positions']
             self._radius[phase] = val['radius']
+            self._insulation_thickness[phase] = val['insulation_thickness']
 
         self._phases = sorted(list(conductors.keys()))
+        self._secondary = is_secondary
 
     @property
     def resistance(self):
@@ -125,3 +127,11 @@ class MultiLineModel:
     @property
     def radius(self):
         return self._radius
+
+    @property
+    def insulation_thickness(self):
+        return self._insulation_thickness
+
+    @property
+    def secondary(self):
+        return self._secondary

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -88,3 +88,40 @@ class ConcentricLineModel:
     @property
     def neutral_strand_count(self):
         return self._neutral_strand_count
+
+
+class MultiLineModel:
+    def __init__(self, conductors):
+        self._resistance = {}
+        self._geometric_mean_radius = {}
+        self._wire_positions = {}
+        self._phases = {}
+        self._radius = {}
+
+        for phase, val in conductors.items():
+            self._resistance[phase] = val['resistance']
+            self._geometric_mean_radius[phase] = val['gmr']
+            self._wire_positions[phase] = val['wire_positions']
+            self._radius[phase] = val['radius']
+
+        self._phases = sorted(list(conductors.keys()))
+
+    @property
+    def resistance(self):
+        return self._resistance
+
+    @property
+    def geometric_mean_radius(self):
+        return self._geometric_mean_radius
+
+    @property
+    def wire_positions(self):
+        return self._wire_positions
+
+    @property
+    def phases(self):
+        return self._phases
+
+    @property
+    def radius(self):
+        return self._radius

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_array_almost_equal
 
 from carsons import MultiConductorCarsonsEquations, calculate_impedance
 from tests.helpers import MultiLineModel
+from tests.test_overhead_line import OHM_PER_MILE_TO_OHM_PER_METER
 
 ureg = pint.UnitRegistry()
 
@@ -33,3 +34,26 @@ def test_triplex_phased_cable():
          [5.922e-5 + 1j * 8.435e-4, 4.388e-4 + 1j * 9.201e-4, 5.922e-5 + 1j * 8.435e-4],
          [5.922e-5 + 1j * 8.435e-4, 5.922e-5 + 1j * 8.435e-4, 4.388e-4 + 1j * 9.201e-4]]
     ), decimal=4)
+
+
+def test_triplex_secondary():
+    """
+    Test against 1/0 AA triplex from example 11.3 in Kersting's book.
+    """
+    conductor = {
+        'resistance': (0.97 * (ohms / miles)).to('ohm / meters').magnitude,
+        'gmr': (0.0111 * feet).to('meters').magnitude,
+        'wire_positions': (0, 1),
+        'radius': (0.368 / 2 * inches).to('meters').magnitude,
+    }
+    phase_conductor = {**conductor, 'insulation_thickness': (0.08 * inches).to('meters').magnitude}
+    neutral_conductor = {**conductor, 'insulation_thickness': 0}
+    multi_line_model = MultiLineModel(
+        {'A': phase_conductor, 'N': neutral_conductor}, is_secondary=True
+    )
+    carsons_model = MultiConductorCarsonsEquations(multi_line_model)
+
+    assert_array_almost_equal(calculate_impedance(carsons_model), array(
+        [[1.5304 + 1j * 0.6132, 0.5574 + 1j * 0.4461],
+         [0.5574 + 1j * 0.4461, 1.5304 + 1j * 0.6132]]
+    ) * OHM_PER_MILE_TO_OHM_PER_METER, decimal=4)

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -25,14 +25,15 @@ def test_triplex_phased_cable():
         'gmr': (0.014 * feet).to('meters').magnitude,
         'wire_positions': (0, 5),
         'radius': (0.464 / 2 * inches).to('meters').magnitude,
+        'insulation_thickness': 0.00137,
     }
     multi_line_model = MultiLineModel({ph: phase_conductor for ph in phases})
     carsons_model = MultiConductorCarsonsEquations(multi_line_model)
 
     assert_array_almost_equal(calculate_impedance(carsons_model), array(
-        [[4.388e-4 + 1j * 9.201e-4, 5.922e-5 + 1j * 8.435e-4, 5.922e-5 + 1j * 8.435e-4],
-         [5.922e-5 + 1j * 8.435e-4, 4.388e-4 + 1j * 9.201e-4, 5.922e-5 + 1j * 8.435e-4],
-         [5.922e-5 + 1j * 8.435e-4, 5.922e-5 + 1j * 8.435e-4, 4.388e-4 + 1j * 9.201e-4]]
+        [[4.389e-4 + 1j * 9.200e-4, 5.922e-5 + 1j * 8.277e-4, 5.922e-5 + 1j * 8.277e-4],
+         [5.922e-5 + 1j * 8.277e-4, 4.389e-4 + 1j * 9.200e-4, 5.922e-5 + 1j * 8.277e-4],
+         [5.922e-5 + 1j * 8.277e-4, 5.922e-5 + 1j * 8.277e-4, 4.389e-4 + 1j * 9.200e-4]]
     ), decimal=4)
 
 

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -59,7 +59,7 @@ def test_triplex_secondary():
     }
     neutral_conductor = {**conductor, 'insulation_thickness': 0}
     multi_line_model = MultiLineModel(
-        {'A': phase_conductor, 'N': neutral_conductor}, is_secondary=True
+        {'S1': phase_conductor, 'S2': phase_conductor, 'N': neutral_conductor}
     )
     carsons_model = MultiConductorCarsonsEquations(multi_line_model)
 

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -86,23 +86,25 @@ EXPECTED_QUADRUPLEX_IMPEDANCE = array(
 
 
 @pytest.mark.parametrize(
-    'phases, resistance, gmr, wire_position, radius, insulation_thickness, expected_result',
-    [
-        ('B', 0.97, 0.0111, (0, 5), 0.368/2, 0.00137, EXPECTED_DUPLEX_IMPEDANCE),
-        ('ABC', 0.484, 0.0158, (0, 5), 0.522/2, 0.00137, EXPECTED_QUADRUPLEX_IMPEDANCE)
-    ]
+    'phases, resistance, gmr, wire_position, radius, insulation_thickness, '
+    'expected_result',
+    [('B', 0.97, 0.0111, (0, 5), 0.368/2, 0.00137, EXPECTED_DUPLEX_IMPEDANCE),
+     ('ABC', 0.484, 0.0158, (0, 5), 0.522/2, 0.00137,
+      EXPECTED_QUADRUPLEX_IMPEDANCE)]
 )
 def test_multi_conductor_cable_with_neutral(
         phases, resistance, gmr, wire_position, radius,
         insulation_thickness, expected_result
 ):
     conductor = {
-        'resistance': (resistance * (ohms / miles)).to('ohm / meters').magnitude,
+        'resistance': (resistance * (ohms / miles)
+                       ).to('ohm / meters').magnitude,
         'gmr': (gmr * feet).to('meters').magnitude,
         'wire_positions': wire_position,
         'radius': (radius * inches).to('meters').magnitude,
     }
-    phase_conductor = {**conductor, 'insulation_thickness': insulation_thickness}
+    phase_conductor = {**conductor,
+                       'insulation_thickness': insulation_thickness}
     neutral_conductor = {**conductor, 'insulation_thickness': 0}
 
     line_model_dict = {ph: phase_conductor for ph in phases}
@@ -111,4 +113,5 @@ def test_multi_conductor_cable_with_neutral(
     multi_line_model = MultiLineModel(line_model_dict)
     carsons_model = MultiConductorCarsonsEquations(multi_line_model)
 
-    assert_array_almost_equal(calculate_impedance(carsons_model), expected_result, decimal=4)
+    assert_array_almost_equal(calculate_impedance(carsons_model),
+                              expected_result, decimal=4)

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -15,6 +15,33 @@ ohms = ureg.ohms
 kft = ureg.feet * 1000
 
 
+def test_duplex_1ph():
+    """
+    Test 1/0 NS75 duplex cable.
+    """
+    phases = 'B'
+    conductor = {
+        'resistance': (0.97 * (ohms / miles)).to('ohm / meters').magnitude,
+        'gmr': (0.0111 * feet).to('meters').magnitude,
+        'wire_positions': (0, 5),
+        'radius': (0.368 / 2 * inches).to('meters').magnitude,
+    }
+    phase_conductor = {**conductor, 'insulation_thickness': 0.00137}
+    neutral_conductor = {**conductor, 'insulation_thickness': 0}
+
+    line_model_dict = {ph: phase_conductor for ph in phases}
+    line_model_dict.update({'N': neutral_conductor})
+
+    multi_line_model = MultiLineModel(line_model_dict)
+    carsons_model = MultiConductorCarsonsEquations(multi_line_model)
+
+    assert_array_almost_equal(calculate_impedance(carsons_model), array(
+        [[0.0 + 1j*0.0, 0.0 + 1j*0.0, 0.0 + 1j*0.0],
+         [0.0 + 1j*0.0, 9.521e-4 + 1j*3.744e-4, 0.0 + 1j*0.0],
+         [0.0 + 1j*0.0, 0.0 + 1j*0.0, 0.0 + 1j*0.0]]
+    ), decimal=4)
+
+
 def test_triplex_phased_cable():
     """
     Test against 3/0 triplex NS75 aluminum conductor cable.
@@ -42,8 +69,9 @@ def test_triplex_phased_cable():
 
 def test_triplex_secondary():
     """
-    Test against 1/0 AA triplex secondary cable from example 11.3
-    in Kersting's book.
+    Test against 1/0 AA triplex secondary cable from example 11.3 on page 463
+    of 'Distribution System Modeling and Analysis' by William H.Kersting,
+    4th edition.
     """
     conductor = {
         'resistance': (0.97 * (ohms / miles)).to('ohm / meters').magnitude,
@@ -65,3 +93,33 @@ def test_triplex_secondary():
         [[1.5304 + 1j * 0.6132, 0.5574 + 1j * 0.4461],
          [0.5574 + 1j * 0.4461, 1.5304 + 1j * 0.6132]]
     ) * OHM_PER_MILE_TO_OHM_PER_METER, decimal=4)
+
+
+def test_quadruplex_3ph():
+    """
+    Test 4/0 NS75 quadruplex cable.
+    """
+    phases = 'ABC'
+    conductor = {
+        'resistance': (0.484 * (ohms / miles)).to('ohm / meters').magnitude,
+        'gmr': (0.0158 * feet).to('meters').magnitude,
+        'wire_positions': (0, 5),
+        'radius': (0.522 / 2 * inches).to('meters').magnitude,
+    }
+    phase_conductor = {**conductor, 'insulation_thickness': 0.00137}
+    neutral_conductor = {**conductor, 'insulation_thickness': 0}
+
+    line_model_dict = {ph: phase_conductor for ph in phases}
+    line_model_dict.update({'N': neutral_conductor})
+
+    multi_line_model = MultiLineModel(line_model_dict)
+    carsons_model = MultiConductorCarsonsEquations(multi_line_model)
+
+    assert_array_almost_equal(calculate_impedance(carsons_model), array(
+        [[5.223e-4 + 1j*2.279e-4, 2.216e-4 + 1j*1.373e-4,
+          2.216e-4 + 1j*1.373e-4],
+         [2.216e-4 + 1j*1.373e-4, 5.223e-4 + 1j*2.279e-4,
+          2.216e-4 + 1j*1.373e-4],
+         [2.216e-4 + 1j*1.373e-4, 2.216e-4 + 1j*1.373e-4,
+          5.223e-4 + 1j*2.279e-4]]
+    ), decimal=4)

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -1,0 +1,35 @@
+import pint
+from numpy import array
+from numpy.testing import assert_array_almost_equal
+
+from carsons import MultiConductorCarsonsEquations, calculate_impedance
+from tests.helpers import MultiLineModel
+
+ureg = pint.UnitRegistry()
+
+feet = ureg.feet
+inches = ureg.inches
+miles = ureg.miles
+ohms = ureg.ohms
+kft = ureg.feet * 1000
+
+
+def test_triplex_phased_cable():
+    """
+    Test against triplex NS75 aluminum conductor cable.
+    """
+    phases = 'ABC'
+    phase_conductor = {
+        'resistance': (0.611 * (ohms / miles)).to('ohm / meters').magnitude,
+        'gmr': (0.014 * feet).to('meters').magnitude,
+        'wire_positions': (0, 5),
+        'radius': (0.464 / 2 * inches).to('meters').magnitude,
+    }
+    multi_line_model = MultiLineModel({ph: phase_conductor for ph in phases})
+    carsons_model = MultiConductorCarsonsEquations(multi_line_model)
+
+    assert_array_almost_equal(calculate_impedance(carsons_model), array(
+        [[4.388e-4 + 1j * 9.201e-4, 5.922e-5 + 1j * 8.435e-4, 5.922e-5 + 1j * 8.435e-4],
+         [5.922e-5 + 1j * 8.435e-4, 4.388e-4 + 1j * 9.201e-4, 5.922e-5 + 1j * 8.435e-4],
+         [5.922e-5 + 1j * 8.435e-4, 5.922e-5 + 1j * 8.435e-4, 4.388e-4 + 1j * 9.201e-4]]
+    ), decimal=4)

--- a/tests/test_multi_conductor.py
+++ b/tests/test_multi_conductor.py
@@ -17,7 +17,7 @@ kft = ureg.feet * 1000
 
 def test_triplex_phased_cable():
     """
-    Test against triplex NS75 aluminum conductor cable.
+    Test against 3/0 triplex NS75 aluminum conductor cable.
     """
     phases = 'ABC'
     phase_conductor = {
@@ -31,15 +31,19 @@ def test_triplex_phased_cable():
     carsons_model = MultiConductorCarsonsEquations(multi_line_model)
 
     assert_array_almost_equal(calculate_impedance(carsons_model), array(
-        [[4.389e-4 + 1j * 9.200e-4, 5.922e-5 + 1j * 8.277e-4, 5.922e-5 + 1j * 8.277e-4],
-         [5.922e-5 + 1j * 8.277e-4, 4.389e-4 + 1j * 9.200e-4, 5.922e-5 + 1j * 8.277e-4],
-         [5.922e-5 + 1j * 8.277e-4, 5.922e-5 + 1j * 8.277e-4, 4.389e-4 + 1j * 9.200e-4]]
+        [[4.389e-4 + 1j*9.200e-4, 5.922e-5 + 1j*8.277e-4,
+          5.922e-5 + 1j*8.277e-4],
+         [5.922e-5 + 1j*8.277e-4, 4.389e-4 + 1j*9.200e-4,
+          5.922e-5 + 1j*8.277e-4],
+         [5.922e-5 + 1j*8.277e-4, 5.922e-5 + 1j*8.277e-4,
+          4.389e-4 + 1j*9.200e-4]]
     ), decimal=4)
 
 
 def test_triplex_secondary():
     """
-    Test against 1/0 AA triplex from example 11.3 in Kersting's book.
+    Test against 1/0 AA triplex secondary cable from example 11.3
+    in Kersting's book.
     """
     conductor = {
         'resistance': (0.97 * (ohms / miles)).to('ohm / meters').magnitude,
@@ -47,7 +51,10 @@ def test_triplex_secondary():
         'wire_positions': (0, 1),
         'radius': (0.368 / 2 * inches).to('meters').magnitude,
     }
-    phase_conductor = {**conductor, 'insulation_thickness': (0.08 * inches).to('meters').magnitude}
+    phase_conductor = {
+        **conductor,
+        'insulation_thickness': (0.08 * inches).to('meters').magnitude
+    }
     neutral_conductor = {**conductor, 'insulation_thickness': 0}
     multi_line_model = MultiLineModel(
         {'A': phase_conductor, 'N': neutral_conductor}, is_secondary=True


### PR DESCRIPTION
- Add support for multi-conductor cables: duplex, triplex, quadruplex. 
- Model triplex secondary as single phase with conductors S1, S2, N.
----

- [x] Add new class for multi-conductor cable.
- [x] Add tests for duplex cable.
- [x] Add tests for triplex cable, 3ph.
- [x] Add tests for quadruplex cable, 3ph.
- [x] Add tests for triplex secondary, 1ph.
- [x] Update doc.
