### PR TITLE
Bump CI to ruff, drop old pythons, add new pythons

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Install lxml deps for building
       if: ${{ startsWith(matrix.python-version, 'pypy' )}}
-      run: sudo apt-get install python3-lxml
+      run: sudo apt-get install libxml2-dev libxslt-dev python-dev python3-lxml
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Install lxml deps for building
       if: ${{ startsWith(matrix.python-version, 'pypy' )}}
-      run: sudo apt-get install libxml2-dev libxslt-dev python-dev python3-lxml
+      run: sudo apt-get install libxml2-dev libxslt-dev python3-lxml
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -63,6 +63,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install lxml deps for building
+      if: ${{ startsWith(matrix.python-version, 'pypy' )}}
+      run: apt install python3-lxml
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -36,9 +36,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: |
-          pip install -e .[test]
-          pip install pycobertura
+        run: pip install -e .[test]
 
       - name: Run tests
         run: pytest --cov --cov-report=xml tests/
@@ -72,25 +70,3 @@ jobs:
     - name: Test with Pytest
       run: |
         pytest tests/
-
-  numpy-compatibility:
-    needs: unit-test
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        numpy-version: ["1.26.4", "2.2.4"]
-        # skipping 3.13 since the unit-test job runs against it
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[test]
-    - name: Run unit-tests with numpy ${{ matrix.numpy-version }}
-      run: |
-        pytest

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Install lxml deps for building
       if: ${{ startsWith(matrix.python-version, 'pypy' )}}
-      run: apt install python3-lxml
+      run: sudo apt-get install python3-lxml
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -12,39 +12,44 @@ on:
       - master
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Latest Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Dependancies
+        run: |
+          pip install -e .[test]
+          pre-commit install
+      - name: Run linting
+        run: pre-commit run --all-files
+
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[test]
-        pre-commit install
-        pre-commit autoupdate
-    - name: Lint with precommit checks
-      run: |
-        pre-commit run --all-files
-    - name: Test with Pytest
-      run: |
-        pytest \
-          --junitxml=junit/test-results.xml \
-          --cov-report=xml --cov=carsons \
-          tests/
-    - name: Make coverage file
-      run: |
-        coverage xml
-    - uses: codecov/codecov-action@v3
-      with:
-        files: ./coverage.xml # optional
-        flags: unittests # optional
-        name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
+      - uses: actions/checkout@v3
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -e .[test]
+          pip install pycobertura
+
+      - name: Run tests
+        run: pytest --cov --cov-report=xml tests/
+
+      - name: Report Coverage In Job Summary
+        run: |
+          echo "## Coverage Report" >> $GITHUB_STEP_SUMMARY
+          coverage report -m --format=markdown >> $GITHUB_STEP_SUMMARY
+
+      - name: Report coverage annotations
+        run: pycobertura show coverage.xml --format github-annotation
 
   compatibility:
     needs: unit-test
@@ -52,8 +57,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.11", pypy3.8, pypy3.9]
-        # skipping 3.10 since the unit-test job runs against it
+        python-version: ["3.10", "3.11", "3.12", "3.13", "pypy3.11"]
+        numpy-version: ["1.26.4", "2.2.4"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[test] numpy==${{ matrix.numpy-version }}
+    - name: Test with Pytest
+      run: |
+        pytest tests/
+
+  numpy-compatibility:
+    needs: unit-test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        numpy-version: ["1.26.4", "2.2.4"]
+        # skipping 3.13 since the unit-test job runs against it
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -64,6 +91,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
-    - name: Test with Pytest
+    - name: Run unit-tests with numpy ${{ matrix.numpy-version }}
       run: |
         pytest

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -20,25 +20,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
+
     - name: Check VERSION
       run: |
         if ! echo ${{ env.PUBLISH_TAG }} | grep -P -e "^\d+\.\d+\.\d+((rc|alpha)\d+)?$"; then
           echo "Tag ${{ env.PUBLISH_TAG }} doesn't match x.y.z pattern. Not pushing.";
           exit 1;
         fi
+
     - name: Build package
       run: |
         echo "Building ${{ env.PUBLISH_TAG }}"
         echo ${{ env.PUBLISH_TAG }} > ${{ env.VERSION_FILE }}
         python -m build
+
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pytest_cache/
 .mypy_cache/
 */__pycache__/
+.ruff_cache
 
 .coverage
 .coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,32 +15,38 @@
 # run a single hook:     pre-commit run --all-files black
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     - id: mixed-line-ending
       args: ['--fix=lf']
       description: Forces to replace line ending by the UNIX 'lf' character.
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: v2.5.1
     hooks:
-      - id: flake8
-        name: Flake PEP8 check
-        additional_dependencies: ["importlib-metadata<=4.13.0"]
-        args: ["--max-line-length=120"]
+      - id: pyproject-fmt
 
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
+  - repo: https://github.com/dhatim/python-license-check
+    rev: "0.9.2"
     hooks:
-      - id: black
-        name: Black autoformatting
+    - id: liccheck
+      language: system
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+  - repo: https://github.com/PyCQA/bandit
+    rev: "1.8.3"
     hooks:
-      - id: isort
+    - id: bandit
+      args: ["-c", "pyproject.toml"]
+      additional_dependencies: ["bandit[toml]"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff  # linter
+        args: [ --fix ]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.991"
+    rev: v1.15.0
     hooks:
       - id: mypy

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ carsons
 [![latest release on pypi](https://badge.fury.io/py/carsons.svg)](https://badge.fury.io/py/carsons)
 [![versons of python supported by carsons](https://img.shields.io/pypi/pyversions/carsons.svg)](https://pypi.python.org/pypi/carsons)
 [![GitHub license](https://img.shields.io/github/license/opusonesolutions/carsons.svg)](https://github.com/opusonesolutions/carsons/blob/master/LICENSE.txt)
-[![build passing or failing](https://github.com/opusonesolutions/carsons/blob/master/.github/workflows/python-package.yaml/badge.svg)](https://travis-ci.org/opusonesolutions/carsons)
-[![test coverage](https://coveralls.io/repos/github/opusonesolutions/carsons/badge.svg?branch=master)](https://coveralls.io/github/opusonesolutions/carsons?branch=master)
-[![Maintainability](https://api.codeclimate.com/v1/badges/22cfed180fd6032fe29b/maintainability)](https://codeclimate.com/github/opusonesolutions/carsons/maintainability)
 
 This is an implementation of Carson's Equations, a mathematical model
 for deriving the equivalent impedance of an AC transmission or

--- a/carsons/__init__.py
+++ b/carsons/__init__.py
@@ -1,4 +1,4 @@
-from carsons.carsons import (  # noqa F401
+from carsons.carsons import (
     CarsonsEquations,
     ConcentricNeutralCarsonsEquations,
     MultiConductorCarsonsEquations,
@@ -9,22 +9,24 @@ from carsons.carsons import (  # noqa F401
     convert_geometric_model,
 )
 
+__all__ = [
+    "CarsonsEquations",
+    "ConcentricNeutralCarsonsEquations",
+    "MultiConductorCarsonsEquations",
+    "TapeShieldedCableCarsonsEquations",
+    "calculate_impedance",
+    "calculate_sequence_impedance_matrix",
+    "calculate_sequence_impedances",
+    "convert_geometric_model",
+]
+
 name = "carsons"
 
 
 def get_version():
-    import sys
+    from importlib.resources import files
 
-    # TODO: if 3.8 support is dropped, we can standardize on
-    # importlib.resources.files
-    if sys.version_info < (3, 9):
-        from importlib.resources import read_text
-
-        return read_text(__name__, "VERSION").strip()
-    else:
-        from importlib.resources import files
-
-        return files(__name__).joinpath("VERSION").open("r").read().strip()
+    return files(__name__).joinpath("VERSION").open("r").read().strip()
 
 
 __version__ = get_version()

--- a/carsons/carsons.py
+++ b/carsons/carsons.py
@@ -1,10 +1,9 @@
 from collections import defaultdict
 from itertools import islice
-from typing import Dict, Iterable, Iterator, Tuple
+from typing import Iterable, Iterator
 
-from numpy import arctan, array, cos, exp, log, ndarray
+from numpy import arctan, array, cos, exp, log, ndarray, sin, sqrt, zeros
 from numpy import pi as π
-from numpy import sin, sqrt, zeros
 from numpy.linalg import inv
 
 alpha = exp(2j * π / 3)
@@ -94,15 +93,14 @@ def calculate_sequence_impedances(Z):
 
 
 class CarsonsEquations:
-
     ρ = 100  # resistivity, ohms/meter^3
     μ = 4 * π * 1e-7  # permeability, Henry / meter
 
     def __init__(self, model):
         self.phases: Iterable[str] = model.phases
-        self.phase_positions: Dict[str, Tuple[float, float]] = model.wire_positions
-        self.gmr: Dict[str, float] = model.geometric_mean_radius
-        self.r: Dict[str, float] = model.resistance
+        self.phase_positions: dict[str, tuple[float, float]] = model.wire_positions
+        self.gmr: dict[str, float] = model.geometric_mean_radius
+        self.r: dict[str, float] = model.resistance
 
         self.ƒ = getattr(model, "frequency", 60)
         self.ω = 2.0 * π * self.ƒ  # angular frequency radians / second
@@ -254,15 +252,15 @@ class ModifiedCarsonsEquations(CarsonsEquations):
 class ConcentricNeutralCarsonsEquations(ModifiedCarsonsEquations):
     def __init__(self, model, *args, **kwargs):
         super().__init__(model)
-        self.neutral_strand_gmr: Dict[str, float] = model.neutral_strand_gmr
-        self.neutral_strand_count: Dict[str, float] = defaultdict(
+        self.neutral_strand_gmr: dict[str, float] = model.neutral_strand_gmr
+        self.neutral_strand_count: dict[str, float] = defaultdict(
             lambda: None, model.neutral_strand_count
         )
-        self.neutral_strand_resistance: Dict[
-            str, float
-        ] = model.neutral_strand_resistance
+        self.neutral_strand_resistance: dict[str, float] = (
+            model.neutral_strand_resistance
+        )
         # fmt: off
-        self.radius: Dict[str, float] = defaultdict(
+        self.radius: dict[str, float] = defaultdict(
             lambda: None,
             {
                 phase: (diameter_over_neutral - model.neutral_strand_diameter[phase]) / 2
@@ -316,7 +314,6 @@ class ConcentricNeutralCarsonsEquations(ModifiedCarsonsEquations):
 
 
 class TapeShieldedCableCarsonsEquations(ModifiedCarsonsEquations):
-
     ρ_tape_shield = 1.7721e-8  # copper resistivity at 20 degrees, ohm-meter
 
     def __init__(self, model, *args, **kwargs):
@@ -373,7 +370,7 @@ class TapeShieldedCableCarsonsEquations(ModifiedCarsonsEquations):
 class MultiConductorCarsonsEquations(ModifiedCarsonsEquations):
     def __init__(self, model):
         super().__init__(model)
-        self.outside_radius: Dict[str, float] = model.outside_radius
+        self.outside_radius: dict[str, float] = model.outside_radius
 
     def compute_d(self, i, j) -> float:
         # Assumptions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ optional-dependencies.test = [
   "liccheck",
   "pint",
   "pre-commit",
+  "pycobertura",
   "pytest>=3.6",
   "pytest-cov",
   # needed by liccheck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,64 +1,100 @@
-[project]
-name = "carsons"
-dynamic = ["version"]
-description = "A python library computing carson's equations."
-classifiers=[
-    "Development Status :: 3 - Alpha",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Scientific/Engineering :: Physics",
-    "Topic :: Scientific/Engineering :: Mathematics",
-]
-keywords=["carsons", "cables", "lines", "power systems", "energy"]
-license = { file = "LICENSE.txt" }
-readme="README.md"
-authors = [
-    { name = "Opus One Solutions" },
-    { email = "rnd@opusonesolutions.com" },
-]
-dependencies = [
-    "numpy>=1.13.1",
-]
-
-[project.optional-dependencies]
-test = [
-    "coveralls",
-    "pint",
-    "pre-commit",
-    "pytest>=3.6",
-    "pytest-cov",
-]
-
-[project.urls]
-repository = "https://github.com/opusonesolutions/carsons"
-
-## build specification
 [build-system]
-requires = ["setuptools >= 61.0.0"]
 build-backend = "setuptools.build_meta"
 
+requires = [ "setuptools>=61" ]
+
+[project]
+name = "carsons"
+description = "A python library computing carson's equations."
+readme = "README.md"
+keywords = [ "cables", "carsons", "energy", "lines", "power systems" ]
+license = { file = "LICENSE.txt" }
+authors = [
+  { name = "Opus One Solutions" },
+  { email = "rnd@opusonesolutions.com" },
+]
+requires-python = ">=3.10"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering :: Mathematics",
+  "Topic :: Scientific/Engineering :: Physics",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dynamic = [ "version" ]
+dependencies = [
+  "numpy>=1.13.1",
+]
+
+optional-dependencies.test = [
+  "coverage>=7.8",
+  # precommit hook doesn't install it for *reasons*
+  "liccheck",
+  "pint",
+  "pre-commit",
+  "pytest>=3.6",
+  "pytest-cov",
+  # needed by liccheck
+  "setuptools",
+]
+## build specification
+urls.repository = "https://github.com/opusonesolutions/carsons"
+
 [tool.setuptools.packages.find]
-include=["carsons*"]
+include = [ "carsons*" ]
 
 [tool.setuptools.dynamic]
-version = {file = ["carsons/VERSION"]}
-
+version = { file = [ "carsons/VERSION" ] }
 
 ## linting configurations
-[tool.isort]
-profile="black"
+
+[tool.ruff]
+lint.extend-select = [ "I" ]
+
+ignore = [ "E741" ]
+
+[tool.coverage.run]
+branch = true
+omit = [ "tests/*" ]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
 
 [tool.mypy]
-files=["carsons", "tests"]
-python_version=3.10
+files = [ "carsons", "tests" ]
+python_version = 3.10
 
 [tool.mypy.overrides]
 warn_unused_configs = true
 warn_unused_ignores = true
 check_untyped_defs = true
+
+[tool.bandit]
+exclude_dirs = [ "tests" ]
+
+[tool.liccheck]
+authorized_licenses = [
+  "BSD",
+  "MIT",
+  "License :: OSI Approved :: MIT",
+  "Apache Software",
+  "Mozilla Public License 2.0 (MPL 2.0)",
+  "LGPLv3+",
+  "LGPLv3",
+  "public domain",
+  "Python Software Foundation",
+]
+unauthorized_licenses = [
+  "GPL v3",
+  "The Unlicense (Unlicense)",
+  "ISC",
+  "ISC License (ISCL)",
+]
+dependencies = true # to load [project.dependencies]

--- a/tests/test_multiple_neutrals.py
+++ b/tests/test_multiple_neutrals.py
@@ -7,7 +7,6 @@ from tests.test_carsons import ACBN_line_z_primitive
 
 
 def test_dual_neutral_model():
-
     model = CarsonsEquations(
         LineModel(
             {


### PR DESCRIPTION
Semi-regular CI maintenance:
* switch to more modern CI tools (new mypy, ruff, add pyproject-fmt)
* include security and license scanning
* drop python 3.9 and lower
* drop codecov